### PR TITLE
Ajuste202011121544

### DIFF
--- a/appv1/get.php
+++ b/appv1/get.php
@@ -8059,14 +8059,19 @@
            
 
             try {
-                $connMSSQL  = getConnectionMSSQLv2();
+                $connMSSQL  = getConnectionMSSQLv1();
                 $stmtMSSQL  = $connMSSQL->prepare($sql00);
 
                     $stmtMSSQL->execute([$val00, $val00]); 
 
                 while ($rowMSSQL = $stmtMSSQL->fetch()) {
-                    $juego_horario  = date_format(date_create($rowMSSQL['juego_horario']), 'd/m/Y H:i:s');
-                    $juego_cierra   = date("Y-m-d", strtotime($rowMSSQL['juego_horario']."+ 10 days"));
+                    if ($rowMSSQL['juego_horario'] == '1900-01-01' || $rowMSSQL['juego_horario'] == null){
+                        $juego_horario  = '';
+                        $juego_cierra   = '';
+                    } else {
+                        $juego_horario  = date_format(date_create($rowMSSQL['juego_horario']), 'd/m/Y H:i:s');
+                        $juego_cierra   = date("Y-m-d", strtotime($rowMSSQL['juego_horario']."+ 10 days"));
+                    }
 
                     $detalle    = array(
                         'competicion_codigo'                    => $rowMSSQL['competicion_codigo'],

--- a/appv2/get.php
+++ b/appv2/get.php
@@ -7898,7 +7898,7 @@
         return $json;
     });
 
-    $app->get('/v2/200/competicion/home/ultimoencuentro/{equipo}', function($request) {//20201106
+    $app->get('/v2/200/competicion/home/ultimoencuentro/{equipo}', function($request) {
         require __DIR__.'/../src/connect.php';
 
         $val00      = $request->getAttribute('equipo');
@@ -7937,8 +7937,13 @@
                     $stmtMSSQL->execute([$val00, $val00]); 
 
                 while ($rowMSSQL = $stmtMSSQL->fetch()) {
-                    $juego_horario  = date_format(date_create($rowMSSQL['juego_horario']), 'd/m/Y H:i:s');
-                    $juego_cierra   = date("Y-m-d", strtotime($rowMSSQL['juego_horario']."+ 10 days"));
+                    if ($rowMSSQL['juego_horario'] == '1900-01-01' || $rowMSSQL['juego_horario'] == null){
+                        $juego_horario  = '';
+                        $juego_cierra   = '';
+                    } else {
+                        $juego_horario  = date_format(date_create($rowMSSQL['juego_horario']), 'd/m/Y H:i:s');
+                        $juego_cierra   = date("Y-m-d", strtotime($rowMSSQL['juego_horario']."+ 10 days"));
+                    }
 
                     $detalle    = array(
                         'competicion_codigo'                    => $rowMSSQL['competicion_codigo'],
@@ -8016,7 +8021,6 @@
         
         return $json;
     });
-
     $app->get('/v2/200/competicion/home/resultado/{equipo}', function($request) {//20201109
         require __DIR__.'/../src/connect.php';
 


### PR DESCRIPTION
Bug: en los horarios de encuentro solo se visualizan una fecha.
Solución: se agregó una condición si el horario se encuentra nulo se visualice vacío.