### PR TITLE
Ajuste202011121606

### DIFF
--- a/appv1/get.php
+++ b/appv1/get.php
@@ -8053,7 +8053,7 @@
                 FROM [view].[juego] a
                 
                 
-                WHERE a.EQUIPO_LOCAL_CODIGO = ? OR a.EQUIPO_VISITANTE_CODIGO = ?
+                WHERE (a.EQUIPO_LOCAL_CODIGO = ? OR a.EQUIPO_VISITANTE_CODIGO = ?) AND a.JUEGO_NOMBRE IS NOT NULL
                 
                 ORDER BY a.JUEGO_CODIGO DESC";
            

--- a/appv2/get.php
+++ b/appv2/get.php
@@ -7925,7 +7925,7 @@
                 FROM [view].[juego] a
                 
                 
-                WHERE a.EQUIPO_LOCAL_CODIGO = ? OR a.EQUIPO_VISITANTE_CODIGO = ?
+                WHERE (a.EQUIPO_LOCAL_CODIGO = ? OR a.EQUIPO_VISITANTE_CODIGO = ?) AND a.JUEGO_NOMBRE IS NOT NULL
                 
                 ORDER BY a.JUEGO_CODIGO DESC";
            


### PR DESCRIPTION
Bug: No se visualiza correctamente los resultados  de los encuentros.
Solución: se agregó una condición en la consulta de la vista de juego que el nombre de equipo sea distinto a nulo 